### PR TITLE
Add support for braces in nginx_http_params.

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -21,7 +21,7 @@ http {
         include {{ nginx_conf_dir }}/mime.types;
         default_type application/octet-stream;
 {% for v in nginx_http_params %}
-        {{ v }};
+        {{ v }}{{ v.endswith('}')|ternary('', ';') }}
 {% endfor %}
 
         include {{ nginx_conf_dir }}/conf.d/*.conf;


### PR DESCRIPTION
Trailing semicolons aren't valid for lines using braces.  See
http://nginx.org/en/docs/http/ngx_http_map_module.html#map for an
example.
